### PR TITLE
remove fontsize property

### DIFF
--- a/demo/body/Source.jsx
+++ b/demo/body/Source.jsx
@@ -72,7 +72,7 @@ class Source extends React.Component {
       <div className={classes.root}>
         <div className={classNames(classes.ctr, { [classes.invalid]: !valid })}>
           <div>
-            <Icon fontSize className={classes.icon} />
+            <Icon className={classes.icon} />
             <div className={classes.title}>
               <p>{title}</p>
             </div>


### PR DESCRIPTION
I tried to run examples locally, but It did not work.
Removing `fontSize` props in Icon solve the problem.