### PR TITLE
date input label always hovers to avoid overlapping

### DIFF
--- a/src/fields/configure/get-label-component-props.js
+++ b/src/fields/configure/get-label-component-props.js
@@ -1,9 +1,14 @@
 import includes from 'lodash/includes';
 
-export default ({ htmlId, required, path }) => {
-  const rv = {
+export default ({ htmlId, required, path, schema }) => {
+  let rv = {
     htmlFor: htmlId,
-    required: includes(required, path),
+    required: includes(required, path)
   };
+
+  if (schema.type === 'date') {
+    rv = { ...rv, shrink: true };
+  }
+
   return rv;
 };


### PR DESCRIPTION
Example:
- schema
    "birthDate": {
      "type": "date",
      "title": "Birth Date"
    }
- formData:
   {} || null
This will have a default localized placeholder on latest chrome, like 'yyyy-mm-dd'.
But the label is also by default laid over the input, so these two overlap.

Settings shrink true for just the date fixes this issue. I have not tested this in any other browsers or setups, but this should never cause issues, at worst "Birth Date" hovers above blank input.

